### PR TITLE
chore(ethereum): upgrade Geth from v1.15.6 to v1.16.2

### DIFF
--- a/ethereum/ethereum-hoodi.yaml
+++ b/ethereum/ethereum-hoodi.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: node
-          image: ethereum/client-go:v1.15.6
+          image: ethereum/client-go:v1.16.2
           command:
             - geth
           args:


### PR DESCRIPTION
## Summary
Upgrades the Ethereum execution client (Geth) from v1.15.6 to v1.16.2.

## Changes
- Updated `ethereum/client-go` image tag in `ethereum/ethereum-hoodi.yaml`

## Release Notes (v1.16.2)
This is a maintenance release that includes:
- **Fusaka EIP implementations**: EIP-7825, EIP-7934, EIP-7939, EIP-7918, EIP-7951, EIP-7892, EIP-7883
- **Core improvements**: Reduced memory allocation in trie hash, file-based state journal, improved freezer sync
- **RPC fixes**: Block overrides in debug_traceCall, new debug_sync endpoint
- **Bug fixes**: Transaction announcements, historical state reader, state history indexer deadlock

Full changelog: https://github.com/ethereum/go-ethereum/releases/tag/v1.16.2

## Testing
- [ ] Verify node syncs correctly with new version
- [ ] Check RPC endpoints respond as expected
- [ ] Monitor resource usage after upgrade